### PR TITLE
Cookware quantity

### DIFF
--- a/__tests__/canonical.yaml
+++ b/__tests__/canonical.yaml
@@ -113,7 +113,8 @@ tests:
             value: "Fry in "
           - type: cookware
             name: "frying pan"
-            quantity: ""
+            quantity: 1
+            amount: "1"
       metadata: []
 
 
@@ -127,7 +128,8 @@ tests:
             value: "Fry in "
           - type: cookware
             name: "7-inch nonstick frying pan"
-            quantity: ""
+            quantity: 1
+            amount: ""
       metadata: []
 
 
@@ -141,7 +143,8 @@ tests:
             value: "Fry in "
           - type: cookware
             name: "frying pan"
-            quantity: ""
+            quantity: 1
+            amount: "1"
       metadata: []
 
 
@@ -155,11 +158,23 @@ tests:
             value: "Simmer in "
           - type: cookware
             name: "pan"
-            quantity: ""
+            quantity: 1
+            amount: "1"
           - type: text
             value: " for some time"
       metadata: []
 
+  testEquipmentQuantity:
+    source: |
+      #frying pan{2}
+    result:
+      steps:
+        -
+          - type: cookware
+            name: "frying pan"
+            quantity: 2
+            amount: "2"
+      metadata: []
 
   testFractions:
     source: |
@@ -172,7 +187,6 @@ tests:
             quantity: 0.5
             units: "cup"
       metadata: []
-
 
   testFractionsInDirections:
     source: |

--- a/__tests__/canonical.yaml
+++ b/__tests__/canonical.yaml
@@ -129,7 +129,7 @@ tests:
           - type: cookware
             name: "7-inch nonstick frying pan"
             quantity: 1
-            amount: ""
+            amount: "1"
       metadata: []
 
 

--- a/__tests__/recipe.test.ts
+++ b/__tests__/recipe.test.ts
@@ -63,6 +63,11 @@ describe.each(Object.keys(tests))("canonical tests", (testName: string) => {
             expect(recipeComponent).toBeInstanceOf(Cookware)
             const cookware = recipeComponent as Cookware
             expect(cookware.name).toBe(resultComponent.name)
+            // split in logic here. For non-number quantities, the string is still in the "amount" field
+            if(typeof cookware.quantity === 'undefined' || isNaN(cookware.quantity))
+              expect(cookware.amount).toBe(resultComponent.quantity)
+            else
+              expect(cookware.quantity).toBe(resultComponent.quantity)
             break;
           case "timer":
             expect(recipeComponent).toBeInstanceOf(Timer)

--- a/dist/cooklang.d.ts
+++ b/dist/cooklang.d.ts
@@ -27,6 +27,8 @@ export declare class Ingredient extends base {
 }
 export declare class Cookware extends base {
     name?: string;
+    amount?: string;
+    quantity?: number;
     constructor(s?: string | string[] | any);
 }
 export declare class Timer extends base {

--- a/dist/cooklang.js
+++ b/dist/cooklang.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.Metadata = exports.Timer = exports.Cookware = exports.Ingredient = exports.Step = exports.Recipe = void 0;
 const COMMENT_REGEX = /(--.*)|(\[-(.|\n)+?-\])/g;
 const INGREDIENT_REGEX = /@(?:([^@#~]+?)(?:{(.*?)}|{\s*}))|@((?:[^@#~\s])+)/;
-const COOKWARE_REGEX = /#(?:([^@#~]+?)(?:{\s*}))|#((?:[^@#~\s])+)/;
+const COOKWARE_REGEX = /#(?:([^@#~]+?)(?:{(.*?)}|{\s*}))|#((?:[^@#~\s])+)/;
 const TIMER_REGEX = /~([^@#~]*){([0-9]+(?:[\/|\.][0-9]+)?)%(.+?)}/;
 const METADATA_REGEX = /^>>\s*(.*?):\s*(.*)$/;
 // a base class containing the raw string
@@ -143,13 +143,22 @@ class Cookware extends base {
         super(s);
         if (s instanceof Array || typeof s === 'string') {
             const match = s instanceof Array ? s : COOKWARE_REGEX.exec(s);
-            if (!match || match.length != 3)
-                throw `error parsing cookware: '${s}'`;
-            this.name = (match[1] || match[2]).trim();
+            if (!match || match.length != 4)
+                throw `error parsing ingredient: '${s}'`;
+            this.name = (match[1] || match[3]).trim();
+            const attrs = match[2];
+            this.amount = attrs && attrs.length > 0 ? attrs[0].trim() : "1";
+            if (!this.amount)
+                this.amount = "1";
+            this.quantity = this.amount ? stringToNumber(this.amount) : 1;
         }
         else {
             if ('name' in s)
                 this.name = s.name;
+            if ('amount' in s)
+                this.amount = s.amount;
+            if ('quantity' in s)
+                this.quantity = s.quantity;
         }
     }
 }

--- a/src/cooklang.ts
+++ b/src/cooklang.ts
@@ -1,6 +1,6 @@
 const COMMENT_REGEX = /(--.*)|(\[-(.|\n)+?-\])/g
 const INGREDIENT_REGEX = /@(?:([^@#~]+?)(?:{(.*?)}|{\s*}))|@((?:[^@#~\s])+)/
-const COOKWARE_REGEX = /#(?:([^@#~]+?)(?:{\s*}))|#((?:[^@#~\s])+)/
+const COOKWARE_REGEX = /#(?:([^@#~]+?)(?:{(.*?)}|{\s*}))|#((?:[^@#~\s])+)/
 const TIMER_REGEX = /~([^@#~]*){([0-9]+(?:[\/|\.][0-9]+)?)%(.+?)}/
 const METADATA_REGEX = /^>>\s*(.*?):\s*(.*)$/
 
@@ -136,16 +136,24 @@ export class Ingredient extends base {
 // cookware
 export class Cookware extends base {
   name?: string
+  amount?: string
+  quantity?: number
 
   constructor(s?: string | string[] | any) {
     super(s)
     if (s instanceof Array || typeof s === 'string') {
       const match = s instanceof Array ? s : COOKWARE_REGEX.exec(s)
-      if (!match || match.length != 3) throw `error parsing cookware: '${s}'`
-      this.name = (match[1] || match[2]).trim()
+      if (!match || match.length != 4) throw `error parsing ingredient: '${s}'`
+      this.name = (match[1] || match[3]).trim()
+      const attrs = match[2]
+      this.amount = attrs && attrs.length > 0 ? attrs[0].trim() : "1"
+      if(!this.amount) this.amount = "1"
+      this.quantity = this.amount ? stringToNumber(this.amount) : 1
     }
     else {
       if ('name' in s) this.name = s.name
+      if ('amount' in s) this.amount = s.amount
+      if ('quantity' in s) this.quantity = s.quantity
     }
   }
 }


### PR DESCRIPTION
Cooklang define that cookware can have quantity which is number or multiword - can be checked here: https://github.com/cooklang/spec/blob/main/EBNF.md

This PR add support for quantity similar to one used for ingredients.